### PR TITLE
Use the new libxmljs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "Apache",
   "dependencies": {
     "colors": "^1.0.3",
-    "libxmljs": "git+https://github.com/gwicke/libxmljs",
+    "libxmljs": "^0.19.5",
     "yargs": "^1.3.3"
   }
 }


### PR DESCRIPTION
The bug which motivated gwicke's fork is fixed, and the old libxmljs does not compile with recent versions of V8.

Confirmed to work on node 8.10.0 as packaged in Ubuntu 18.04. I confirmed that the current package.json is broken with both node 8.10.0 and node 4.2.6.